### PR TITLE
Swift 4 & Xcode 9 Updates

### DIFF
--- a/Sources/NSDictionary+UserTheme.swift
+++ b/Sources/NSDictionary+UserTheme.swift
@@ -91,7 +91,7 @@ extension NSDictionary {
         // Resolve any variables
         var evaluatedStringValue = stringValue
         var rangeOffset = 0
-        NSDictionary.varsRegExpr?.enumerateMatches(in: stringValue, options: NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.characters.count), using: { (match, flags, stop) in
+        NSDictionary.varsRegExpr?.enumerateMatches(in: stringValue, options: NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.count), using: { (match, flags, stop) in
             if let matchRange = match?.range(at: 1) {
                 var range = matchRange
                 range.location += rangeOffset
@@ -99,7 +99,7 @@ extension NSDictionary {
                 // Extract variable
                 let start = range.location + 1
                 let end = start + range.length - 2
-                guard start < evaluatedStringValue.characters.count && end < evaluatedStringValue.characters.count else { return }
+                guard start < evaluatedStringValue.count && end < evaluatedStringValue.count else { return }
                 let variable = evaluatedStringValue[start..<end]
                 
                 // Evaluated value
@@ -107,7 +107,7 @@ extension NSDictionary {
                     evaluatedStringValue = evaluatedStringValue.replacingCharacters(inNSRange: range, with: variableValue)
                     
                     // Move offset forward
-                    rangeOffset = variableValue.characters.count - range.length
+                    rangeOffset = variableValue.count - range.length
                 }
                 else {
                     // Move offset forward
@@ -129,7 +129,7 @@ extension NSDictionary {
         var evaluatedObject: AnyObject? = value
             
         // linear-gradient(color1, color2)
-        if let match = NSDictionary.linearGradRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.characters.count)),
+        if let match = NSDictionary.linearGradRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.count)),
             match.numberOfRanges == 11 {
             
             // Starting color
@@ -152,7 +152,7 @@ extension NSDictionary {
         
         // rgb/rgba color
         if evaluatedObject is String,
-            let match = NSDictionary.colorRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.characters.count)),
+            let match = NSDictionary.colorRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.count)),
             match.numberOfRanges == 5 {
             
             let red = (Float(stringValue.substring(withNSRange: match.range(at: 1))) ?? 255) / 255
@@ -166,7 +166,7 @@ extension NSDictionary {
         
         // pattern
         if evaluatedObject is String,
-            let match = NSDictionary.patternRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.characters.count)),
+            let match = NSDictionary.patternRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.count)),
             match.numberOfRanges == 6 {
                 
             let isNamedType = stringValue.substring(withNSRange: match.range(at: 2)) == "named"
@@ -190,7 +190,7 @@ extension NSDictionary {
         
         // image
         if evaluatedObject is String,
-            let match = NSDictionary.imageRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.characters.count)),
+            let match = NSDictionary.imageRegExpr?.firstMatch(in: stringValue, options:NSRegularExpression.MatchingOptions(rawValue: UInt(0)), range: NSMakeRange(0, stringValue.count)),
             match.numberOfRanges == 6 {
             
             let isNamedType = stringValue.substring(withNSRange: match.range(at: 2)) == "named"

--- a/Sources/String+Substring.swift
+++ b/Sources/String+Substring.swift
@@ -30,7 +30,7 @@ extension String {
     
     /// Convenience function to get substring with NSRange.
     internal func substring(withNSRange: NSRange) -> String {
-        guard withNSRange.location < self.characters.count else { return "" }
+        guard withNSRange.location < self.count else { return "" }
         let start = self.index(self.startIndex, offsetBy: withNSRange.location)
         let end = self.index(start, offsetBy: withNSRange.length)
         let range = Range<String.Index>(uncheckedBounds: (lower: start, upper: end))
@@ -39,7 +39,7 @@ extension String {
     
     /// Convenience function to replace characters with NSRange.
     internal func replacingCharacters(inNSRange: NSRange, with: String) -> String {
-        guard inNSRange.location < self.characters.count else { return "" }
+        guard inNSRange.location < self.count else { return "" }
         let start = self.index(self.startIndex, offsetBy: inNSRange.location)
         let end = self.index(start, offsetBy: inNSRange.length)
         let range = Range<String.Index>(uncheckedBounds: (lower: start, upper: end))

--- a/ThemeKit.xcodeproj/xcshareddata/xcschemes/ThemeKit.xcscheme
+++ b/ThemeKit.xcodeproj/xcshareddata/xcschemes/ThemeKit.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0910"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "286DE7C71D92DF8F00767E00"
+               BuildableName = "ThemeKit.framework"
+               BlueprintName = "ThemeKit"
+               ReferencedContainer = "container:ThemeKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "286DE7C71D92DF8F00767E00"
+            BuildableName = "ThemeKit.framework"
+            BlueprintName = "ThemeKit"
+            ReferencedContainer = "container:ThemeKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "286DE7C71D92DF8F00767E00"
+            BuildableName = "ThemeKit.framework"
+            BlueprintName = "ThemeKit"
+            ReferencedContainer = "container:ThemeKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/macOSThemeKit.podspec
+++ b/macOSThemeKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'macOSThemeKit'
-  s.version      = '1.1.0'
+  s.version      = '1.1.1'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.summary      = 'macOS Theming Framework'
   s.homepage     = 'https://github.com/luckymarmot/ThemeKit'


### PR DESCRIPTION
- Fixed warnings related to using String.characters.count instead of String.count in Swift 4 as the former is now deprecated
- Set the .xcproject schema to "shared" in order for Carthage to automatically create a build when using `carthage update`