### PR TITLE
fix a crash with EXC_BAD_INSTRUCTION

### DIFF
--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -19,6 +19,6 @@ func CacheKey(selector: Selector, theme: Theme?) -> NSNumber {
 }
 
 func CacheKey(selector: Selector, colorSpace: NSColorSpace?, theme: Theme?) -> NSNumber {
-    let hashValue = selector.hashValue + (colorSpace == nil ? 0 : (colorSpace!.hashValue << 4)) + (theme == nil ? 0 : (theme!.hash << 8))
+    let hashValue = selector.hashValue ^ (colorSpace == nil ? 0 : (colorSpace!.hashValue << 4)) ^ (theme == nil ? 0 : (theme!.hash << 8))
     return NSNumber(value: hashValue)
 }


### PR DESCRIPTION
fix a crash with EXC_BAD_INSTRUCTION(number overflow),use ^ instead of +
<img width="1011" alt="hashcrash" src="https://user-images.githubusercontent.com/5902068/46143865-e3091280-c28d-11e8-98e4-3819e6b49859.png">

