### PR TITLE
Fix misc macOS Mojave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Packages/
 # Carthage
 Carthage/Checkouts
 Carthage/Build
+
+Demo/Index

--- a/Sources/ThemeManager.swift
+++ b/Sources/ThemeManager.swift
@@ -373,12 +373,16 @@ public class ThemeManager: NSObject {
 
     /// Convenience method to get the light appearance.
     @objc public var lightAppearance: NSAppearance? {
-        return NSAppearance(named: NSAppearance.Name.vibrantLight)
+        return NSAppearance(named: .aqua)
     }
 
     /// Convenience method to get the dark appearance.
     @objc public var darkAppearance: NSAppearance? {
-        return NSAppearance(named: NSAppearance.Name.vibrantDark)
+        if #available(OSX 10.14, *) {
+            return NSAppearance(named: .darkAqua)
+        } else {
+            return NSAppearance(named: .vibrantDark)
+        }
     }
 
     // MARK: -


### PR DESCRIPTION
This is a suggestion to update the default light theme to `NSAppearance.aqua` and the dark theme to `NSAppearance.darkAqua`.

`.darkAqua` is only available on macOS Mojave, but looks a lot better than `.vibrantDark`. It falls back on `.vibrantDark` on previous OS versions (the API isn't available before 10.14).

FYI, [Paw 3.1.8](https://paw.cloud/updates/3.1.8) implements this change already and it looks quite nice 😉 